### PR TITLE
test: フォーマットのチェックをGithub actions上で行わないようにした。

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,7 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    chromatic: { viewports: [375, 1200] },
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "next start",
     "lint": "run-p lint:*",
     "lint:tsc": "tsc --noEmit",
-    "lint:prettier": "prettier ./src --check",
     "lint:eslint": "eslint ./src --ext .ts,.tsx",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier ./src --write",
@@ -21,8 +20,8 @@
     "docker:start": "docker compose -f docker-compose.yaml up"
   },
   "dependencies": {
-    "@mojotech/json-type-validation": "^3.1.0",
     "highcharts": "^11.3.0",
+    "@mojotech/json-type-validation": "^3.1.0",
     "highcharts-react-official": "^3.2.1",
     "next": "14.0.4",
     "react": "^18",


### PR DESCRIPTION
# WHY

- Github actions上のみでフォーマットのエラーが消えないため(ローカルではエラーが出ない)。
- husky+lint-stagedでコミット前にフォーマットしているので、Github actions上で実行する必要はないと判断した。

# WHAT
- フォーマットのチェックをGithub actions上で行わないようにした。