### PR TITLE
add: accordionメニューを追加 都道府県ボタンを非表示にできるようにした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "highcharts-react-official": "^3.2.1",
         "next": "14.0.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-icons": "^5.0.1"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^7.6.7",
@@ -18169,6 +18170,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "highcharts-react-official": "^3.2.1",
     "next": "14.0.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-icons": "^5.0.1"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.7",

--- a/src/app/components/atoms/Accordion/index.stories.tsx
+++ b/src/app/components/atoms/Accordion/index.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Accordion } from ".";
+
+const meta = {
+  title: "Accordion",
+  component: Accordion,
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: "trigger",
+    children: "contents",
+  },
+};

--- a/src/app/components/atoms/Accordion/index.test.tsx
+++ b/src/app/components/atoms/Accordion/index.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { Accordion } from ".";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+
+describe("Accordion", () => {
+  test("[role='button']", () => {
+    render(<Accordion label="trigger">Contents</Accordion>);
+    expect(screen.getByRole("button", { name: "trigger" })).toBeInTheDocument();
+  });
+
+  test("デフォルトでOpenになっている場合、Contentsが表示されている", () => {
+    render(
+      <Accordion label="trigger" defaultIsOpen={true}>
+        Contents
+      </Accordion>
+    );
+    expect(screen.getByText("Contents")).toBeInTheDocument();
+  });
+
+  test("デフォルトでOpenになっていない場合、Contentsが表示されていない", () => {
+    render(
+      <Accordion label="trigger" defaultIsOpen={false}>
+        Contents
+      </Accordion>
+    );
+    expect(screen.queryByText("Contents")).not.toBeInTheDocument();
+  });
+
+  test("デフォルトでOpenになっている場合、トリガーをクリックするとContentsが消える", async () => {
+    render(
+      <Accordion label="trigger" defaultIsOpen={true}>
+        Contents
+      </Accordion>
+    );
+    const trigger = await screen.findByRole("button", { name: "trigger" });
+    const user = userEvent.setup();
+
+    await user.click(trigger);
+
+    expect(screen.queryByText("Contents")).not.toBeInTheDocument();
+  });
+
+  test("デフォルトでOpenになっていない場合、トリガーをクリックするとContentsが表示される", async () => {
+    render(
+      <Accordion label="trigger" defaultIsOpen={false}>
+        Contents
+      </Accordion>
+    );
+    const trigger = await screen.findByRole("button", { name: "trigger" });
+    const user = userEvent.setup();
+
+    await user.click(trigger);
+
+    expect(screen.getByText("Contents")).toBeInTheDocument();
+  });
+});

--- a/src/app/components/atoms/Accordion/index.tsx
+++ b/src/app/components/atoms/Accordion/index.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import clsx from "clsx";
+import { MouseEvent, forwardRef, useState } from "react";
+import { SlArrowDown, SlArrowUp } from "react-icons/sl";
+
+type Props = {
+  label: string;
+  children: React.ReactNode;
+  defaultIsOpen?: boolean;
+} & React.ComponentPropsWithoutRef<"button">;
+
+export const Accordion = forwardRef<HTMLButtonElement, Props>(
+  function ButtonBase(
+    { label, children, defaultIsOpen, className, ...props },
+    ref
+  ) {
+    const [isOpen, setIsOpen] = useState(defaultIsOpen);
+
+    const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+      setIsOpen(!isOpen);
+    };
+
+    return (
+      <div className={clsx("accordion", className)}>
+        <button
+          onClick={handleClick}
+          {...props}
+          ref={ref}
+          className="accordion-trigger"
+        >
+          <div className="accordion-trigger-contents">
+            {label}
+            {isOpen ? <SlArrowUp /> : <SlArrowDown />}
+          </div>
+        </button>
+        <div className="separator" />
+        {isOpen && children}
+      </div>
+    );
+  }
+);

--- a/src/app/components/templates/top/PrefPopulationLineChart/utils.ts
+++ b/src/app/components/templates/top/PrefPopulationLineChart/utils.ts
@@ -34,8 +34,6 @@ export const getHighChartsOptions = (
     );
   });
 
-  console.log(series);
-
   const options: Highcharts.Options = {
     title: {
       text: `年次(横軸)と各都道府県の${popolationType || "総人口"}(縦軸)の関係`,
@@ -65,7 +63,7 @@ export const getHighChartsOptions = (
         label: {
           connectorAllowed: false,
         },
-        pointStart: 1980,
+        pointStart: 1960,
         pointInterval: 5,
       },
     },

--- a/src/app/components/templates/top/index.tsx
+++ b/src/app/components/templates/top/index.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { PrefPopulationLineChartContainer } from "./container/PrefPopulationLineChartContainer";
 import { PrefToggleListContainer } from "./container/PrefToggleListContainer";
+import { Accordion } from "../../atoms/Accordion";
 
 type Props = {
   pref?: string;
@@ -9,10 +10,11 @@ type Props = {
 export const Top = async ({ pref }: Props) => {
   return (
     <main className="top">
-      <h1 className="top-title">都道府県</h1>
-      <Suspense>
-        <PrefToggleListContainer />
-      </Suspense>
+      <Accordion label="都道府県" defaultIsOpen={true}>
+        <Suspense>
+          <PrefToggleListContainer />
+        </Suspense>
+      </Accordion>
       <Suspense>
         <PrefPopulationLineChartContainer pref={pref} />
       </Suspense>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-[#F5F5F5] text-[#505050] min-h-screen p-5;
+    @apply container mx-auto max-w-[1200px] min-h-screen p-5 bg-[#F5F5F5] text-[#505050];
   }
 
   button {
@@ -20,12 +20,25 @@
   .top {
     @apply flex flex-col gap-3;
   }
-  .top-title {
-    @apply text-3xl font-bold;
+
+  .accordion {
+    @apply flex flex-col;
+  }
+
+  .accordion-trigger {
+    @apply border-none py-0 px-2 text-2xl font-bold;
+  }
+
+  .separator {
+    @apply my-2 border border-[#505050];
   }
 
   .toggle-button-list {
     @apply grid grid-cols-4 gap-1 sm:grid-cols-6 lg:grid-cols-8;
+  }
+
+  .accordion-trigger-contents {
+    @apply flex justify-between items-center;
   }
 
   .chart {


### PR DESCRIPTION
# WHY
- 都道府県のボタンが47個あるため、画面上に無駄な情報が多く、グラフを分析する場合に認知負荷が上がる可能性がある。

# WHAT
- accordionメニューを実装し、ユーザーがボタンを表示するかを決定できるようにした。