### PR TITLE
fix: API RoutesのURLをlocalhostから変更した

### DIFF
--- a/src/services/population/index.ts
+++ b/src/services/population/index.ts
@@ -49,7 +49,7 @@ export const fetchPopulationByPrefCode = async (
 ): Promise<fetchPopulationReturn> => {
   try {
     const res = await fetch(
-      `http://localhost:3000/api/population/${prefCode}`,
+      `https://yumemi-frontend-selection.vercel.app/api/population/${prefCode}`,
       {
         method: "GET",
       }

--- a/src/services/prefectures/index.ts
+++ b/src/services/prefectures/index.ts
@@ -21,9 +21,12 @@ const fetchPrefectureReturnsDecoder: Decoder<fetchPrefecturesReturn> = object({
 export const fetchPrefectureNames =
   async (): Promise<fetchPrefecturesReturn> => {
     try {
-      const res = await fetch("http://localhost:3000/api/prefectures", {
-        method: "GET",
-      });
+      const res = await fetch(
+        "https://yumemi-frontend-selection.vercel.app/api/prefectures",
+        {
+          method: "GET",
+        }
+      );
 
       const prefectures = await res
         .json()


### PR DESCRIPTION
# WHY
- API RoutesのURLを開発時のlocalhostのままにしていたため、デプロイしたときにエラーがでた

# WHAT
- デプロイしたときのリンクに置き換えた

# DISCUSS
- 環境変数などを使って、うまく切り替えるべき？そもそもできるのか？