### PR TITLE
fix: 本番環境と開発環境のURLを環境変数で設定した

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+APP_URL="http://localhost:3000"

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+APP_URL="https://yumemi-frontend-selection.vercel.app"

--- a/src/services/population/index.ts
+++ b/src/services/population/index.ts
@@ -49,7 +49,7 @@ export const fetchPopulationByPrefCode = async (
 ): Promise<fetchPopulationReturn> => {
   try {
     const res = await fetch(
-      `https://yumemi-frontend-selection.vercel.app/api/population/${prefCode}`,
+      `${process.env.APP_URL}/api/population/${prefCode}`,
       {
         method: "GET",
       }

--- a/src/services/prefectures/index.ts
+++ b/src/services/prefectures/index.ts
@@ -21,12 +21,9 @@ const fetchPrefectureReturnsDecoder: Decoder<fetchPrefecturesReturn> = object({
 export const fetchPrefectureNames =
   async (): Promise<fetchPrefecturesReturn> => {
     try {
-      const res = await fetch(
-        "https://yumemi-frontend-selection.vercel.app/api/prefectures",
-        {
-          method: "GET",
-        }
-      );
+      const res = await fetch(`${process.env.APP_URL}/api/prefectures`, {
+        method: "GET",
+      });
 
       const prefectures = await res
         .json()


### PR DESCRIPTION
# WHY
- https://github.com/DoiRyoto/yumemi-frontend-selection/pull/7における修正が、開発時にもデプロイ先のURLにアクセスするような変更であり、本番環境のサーバーに負荷をかけることになっていたため。

# WHAT
- 環境変数によって、開発環境と本番環境でリクエストを送るURLを切り替えることができるようにした。